### PR TITLE
商品詳細ページの機能実装

### DIFF
--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -65,6 +65,7 @@
           line-height: 1.5;
           font-size: 18px;
           margin-bottom: 30px;
+          word-break: break-word;
         }
         .table {
           margin-bottom: 20px;

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -11,6 +11,7 @@ class ItemsController < ApplicationController
   end
 
   def show
+    @item = Item.find(params[:id])
     render layout: 'compact'
   end
 

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,9 +1,7 @@
 .productList
   = link_to item_path(item.id) do
     .productList--img
-      - item.images.each.with_index(1) do |image,i|
-        - if i == 1
-          = image_tag("#{image.image}")
+      = image_tag ("#{item.images.first.image}")
     .productList--body
       = item.name
       %h3.name

--- a/app/views/items/_item.html.haml
+++ b/app/views/items/_item.html.haml
@@ -1,7 +1,9 @@
 .productList
   = link_to item_path(item.id) do
     .productList--img
-      = image_tag "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"
+      - item.images.each.with_index(1) do |image,i|
+        - if i == 1
+          = image_tag("#{image.image}")
     .productList--body
       = item.name
       %h3.name

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -87,7 +87,7 @@
         %h2.head ピックアップカテゴリー
         .productBox
           .productHead
-            %a{href: "#"}
+            = link_to "#" do
               %h3.title 新規投稿商品
           .productLists
             - @items[0..5].each do |item|
@@ -98,7 +98,7 @@
       %h2.head ピックアップブランド
       .productBox
         .productHead
-          %a{href: "#"}
+          = link_to "#" do
             %h3.title アーカイバ
           .productLists
             - @items[0..5].each do |item|
@@ -110,9 +110,9 @@
       %h2.appBanner__Inner__Title だれでもかんたん、人生を変えるフリマアプリ
       %p.appBanner__Inner__Text 今すぐ無料ダウンロード！
       .appBanner__Inner__Icon
-        %a{href:"#"}
+        = link_to "#" do
           = image_tag "material/app-store.svg", class:"image"
-        %a{href: "#"}
+        = link_to "#" do
           = image_tag "material/google-play.svg", class:"image"
 
     = link_to new_item_path do

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -9,22 +9,14 @@
           .itemBox__body
             %ul
               %li
-                - @item.images.each.with_index(1) do |image,i|
-                  - if i == 1
-                    = image_tag("#{image.image}")
+                = image_tag("#{@item.images.first.image}")
                 %ul
                   %li
-                    - @item.images.each.with_index(1) do |image,i|
-                      - if i == 2
-                        = image_tag("#{image.image}")
+                    = image_tag("#{@item.images.first.image}")
                   %li
-                    - @item.images.each.with_index(1) do |image,i|
-                      - if i == 3
-                        = image_tag("#{image.image}")
+                    = image_tag("#{@item.images.first.image}")
                   %li
-                    - @item.images.each.with_index(1) do |image,i|
-                      - if i == 4
-                        = image_tag("#{image.image}")
+                    = image_tag("#{@item.images.first.image}")
           .itemBox__price
             %span
               = "#{@item.price}円"

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -45,7 +45,7 @@
                 %tr
                   %th カテゴリー
                   %td
-                    %a{:href => "#"}
+                    = link_to "#" do
                       = @item.category.parent.parent.name
                       %br
                       %i{class: "fas fa-chevron-right"}
@@ -71,7 +71,7 @@
                 %tr
                   %th 発送元の地域
                   %td
-                    %a{:href => "#"}
+                    = link_to "#" do
                       = @item.region
                 %tr
                   %th 発送日の目安
@@ -84,7 +84,7 @@
                 お気に入り 0
             %ul.optional
               %li.optionalBtn
-                %a{:href => "#"}
+                = link_to "#" do
                   %i.fa.fa-flag
                   不適切な商品の通報
         .commentBox
@@ -103,14 +103,14 @@
               コメントする
       %ul.links
         %li
-          %a{:href => "#"}
+          = link_to "#" do
             %i.fa.fa-angle-left
             %span
             前の商品
         %li
-          %a{:href => "#"}
+          = link_to "#" do
             %span 後ろの商品
             %i.fa.fa-angle-right
       .relatedItems
-        %a{:href => "#"} ベビー・キッズをもっと見る
+        = link_to "ベビー・キッズをもっと見る", "#"
         .productLists

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -4,60 +4,79 @@
     .contentRight
       .topContent
         .itemBox
-          %h2.itemBox__name product3
+          %h2.itemBox__name
+            = @item.name
           .itemBox__body
             %ul
               %li
-                %img{:src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png"}/
+                - @item.images.each.with_index(1) do |image,i|
+                  - if i == 1
+                    = image_tag("#{image.image}")
                 %ul
                   %li
-                    %img{:height => "75", :src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/13/a007.png", :width => "75"}/
+                    - @item.images.each.with_index(1) do |image,i|
+                      - if i == 2
+                        = image_tag("#{image.image}")
                   %li
-                    %img{:height => "75", :src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/14/a001.png", :width => "75"}/
+                    - @item.images.each.with_index(1) do |image,i|
+                      - if i == 3
+                        = image_tag("#{image.image}")
                   %li
-                    %img{:height => "75", :src => "https://s3-ap-northeast-1.amazonaws.com/mercarimaster/uploads/captured_image/content/15/a003.png", :width => "75"}/
+                    - @item.images.each.with_index(1) do |image,i|
+                      - if i == 4
+                        = image_tag("#{image.image}")
           .itemBox__price
             %span
-              ¥30000
+              = "#{@item.price}円"
             .itemBox__price-detail
               %span
                 (税込)
               %span
                 送料込み
-          .itemDetail 親譲りの無鉄砲で小供の時から損ばかりしている。小学校に居る時分学校の二階から飛び降りて一週間ほど腰を抜かした事がある。なぜそんな無闇をしたと聞く人があるかも知れぬ。別段深い理由でもない。新築の二階から首を出していたら、同級生の一人が冗談に、いくら威張っても、そこから飛び降りる事は出来まい。弱虫やーい。と囃したからである。小使に負ぶさって帰って来た時、おやじが大きな眼をして二階ぐらいから飛び降りて腰
+          .itemDetail
+            =@item.introduction 
           .table
             %table
               %tbody
                 %tr
                   %th 出品者
-                  %td hoge
+                  %td 
+                    = @item.user_id
                 %tr
                   %th カテゴリー
                   %td
-                    %a{:href => "#"} ベビー・キッズ
-                    %br/
-                    %a{:href => "#"} ベビー服(男女兼用)  ~95cm
-                    %br/
-                    %a{:href => "#"} アウター
+                    %a{:href => "#"}
+                      = @item.category.parent.parent.name
+                      %br
+                      %i{class: "fas fa-chevron-right"}
+                      = @item.category.parent.name
+                      %br
+                      %i{class: "fas fa-chevron-right"}
+                      = @item.category.name
                 %tr
                   %th ブランド
                   %td
+                    = @item.brand
                 %tr
                   %th 商品のサイズ
                   %td
                 %tr
                   %th 商品の状態
-                  %td 未使用に近い
+                  %td
+                    = @item.condition
                 %tr
                   %th 配送料の負担
-                  %td 送料込み（出品者負担）
+                  %td
+                    = @item.postage_player
                 %tr
                   %th 発送元の地域
                   %td
-                    %a{:href => "#"} 岩手県
+                    %a{:href => "#"}
+                      = @item.region
                 %tr
                   %th 発送日の目安
-                  %td 4-7日で発送
+                  %td
+                    = @item.preparation_days
           .optionalArea
             %ul
               %li#likeBtn.optionalBtn.likeBtn

--- a/db/migrate/20200508061628_create_items.rb
+++ b/db/migrate/20200508061628_create_items.rb
@@ -9,7 +9,7 @@ class CreateItems < ActiveRecord::Migration[5.0]
       t.string :condition, null: false
       t.string :postage_player, null: false
       t.string :region, null: false
-      t.integer :preparation_days, null: false
+      t.string :preparation_days, null: false
       t.integer :price, null: false
       t.references :user, null: false, foreign_key: true
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -45,7 +45,7 @@ ActiveRecord::Schema.define(version: 20200512020333) do
     t.string   "condition",                      null: false
     t.string   "postage_player",                 null: false
     t.string   "region",                         null: false
-    t.integer  "preparation_days",               null: false
+    t.string   "preparation_days",               null: false
     t.integer  "price",                          null: false
     t.integer  "user_id",                        null: false
     t.datetime "created_at",                     null: false


### PR DESCRIPTION
# what
-  app/assets/stylesheets/items/_show.scss
→はみ出ないように、文字を折り返す
- app/controllers/items_controller.rb
→送られてきた商品の定義
- app/views/items/_item.html.haml
→商品画像を表示
- app/views/items/show.html.haml
→該当商品のDB情報を表示する記述　ユーザーネームは実装後やる予定　アクティブハッシュでの管理もこれから
- db/migrate/20200508061628_create_items.rb
→うまく表示されないので、一旦この型に変更

# why
商品詳細を確認するため

https://gyazo.com/672dddf7673c3437f875ef013b6d882e