### PR TITLE
商品編集機能を大仁さんにバトンタッチ

### DIFF
--- a/app/assets/stylesheets/items/_new.scss
+++ b/app/assets/stylesheets/items/_new.scss
@@ -145,14 +145,19 @@
       border: 0px solid #000;
     }
     .link-blue {
-      display: flex;
-      justify-content: center;
-      margin-bottom: 32px;
+      display: block;
+      text-align: center;
       color: #0095ee;
       text-decoration: none;
     }
     &__caution {
+      margin-top: 32px;
       font-size: 12px;
+    }
+    &__create{
+      text-align: center;
+      font-size: 20px;
+      font-weight: bold;
     }
   }
 }

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -55,4 +55,8 @@ class ItemsController < ApplicationController
     @item = Item.find(params[:id])
   end
 
+  def set_images
+    @images = Image.where(item_id: params[:id])
+  end
+
 end

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -1,4 +1,5 @@
 class ItemsController < ApplicationController
+  before_action :set_item, except: [:index, :new, :create]
 
   def index
     @items = Item.all.order(created_at: :desc)
@@ -48,6 +49,10 @@ class ItemsController < ApplicationController
   private
   def item_params
     params.require(:item).permit(:name, :introduction, :category_id, :size, :brand, :condition, :postage_player, :region, :preparation_days, :price, images_attributes: [:image, :_destroy, :id]).merge(user_id: current_user.id)
+  end
+
+  def set_item
+    @item = Item.find(params[:id])
   end
 
 end

--- a/app/views/items/create.html.haml
+++ b/app/views/items/create.html.haml
@@ -1,0 +1,12 @@
+.new-wrapper
+  .new-wrapper__header
+    = link_to root_path do
+      = image_tag "material/logo/logo.png"
+  .new-wrapper__main
+    .new-wrapper__main__create
+      商品の出品が完了しました
+      %br
+      = link_to root_path,class: "link-blue" do
+        トップページに戻る
+      = link_to product_path(1),class: "link-blue" do
+        商品詳細ページをみる

--- a/app/views/items/edit.html.haml
+++ b/app/views/items/edit.html.haml
@@ -1,0 +1,1 @@
+= render "items/form"

--- a/app/views/items/set_images.json.jbuilder
+++ b/app/views/items/set_images.json.jbuilder
@@ -1,0 +1,1 @@
+json.images @images

--- a/app/views/layouts/compact.html.haml
+++ b/app/views/layouts/compact.html.haml
@@ -33,9 +33,11 @@
             %ul.brandsPulldown.displayNone
         %ul.header__Nav__listsRight
           %li.header__Nav__listsRight__item.header__Nav__listsRight__item--login
-            %a{href: "#"} ログイン
+            = link_to new_user_session_path do
+              ログイン
           %li.header__Nav__listsRight__item.header__Nav__listsRight__item--new
-            %a{href: "#"} 新規会員登録
+            = link_to new_user_registration_path do
+              新規会員登録
         
     = yield
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,12 +10,10 @@ Rails.application.routes.draw do
  
   resources :items do
     collection do
-      # get "set_images"
-      # 編集箇所ここから
+      get "set_images"
       get "set_parents"
       get "set_children"
       get "set_grandchildren"
-      # 編集箇所ここまで
     end
     resources :orders, only: [:index] do
     end


### PR DESCRIPTION
# What
ログイン/新規登録ページへのリンクを記述
create.html.haml・edit.html.hamlの作成
商品情報編集ページまで飛べるにした
🚨次の作業は、商品に紐づく画像が拾ってこれないところから

# Why
本アプリケーションにいける必須機能のため

## 行った作業
☑︎これまでの挙動の確認（ログイン→出品、カテゴリー機能）

☑︎app/views/layouts/compact.html.haml
　headerに、ログイン/新規登録ページへのリンクを記述

☑︎app/views/items/create.html.haml、app/assets/stylesheets/items/_new.scss
　何も記述していなかったので、hamlとscssの記述

☑︎app/views/items/edit.html.haml
　new.html.hamlのコードをコピペ