### PR TITLE
商品出品機能(出品中/売却済みの状態を登録できるようにする)

### DIFF
--- a/db/migrate/20200518122346_add_column_item_soldout.rb
+++ b/db/migrate/20200518122346_add_column_item_soldout.rb
@@ -1,0 +1,4 @@
+class AddColumnItemSoldout < ActiveRecord::Migration[5.0]
+  def change
+  end
+end

--- a/db/migrate/20200518122346_add_column_item_soldout.rb
+++ b/db/migrate/20200518122346_add_column_item_soldout.rb
@@ -1,4 +1,5 @@
 class AddColumnItemSoldout < ActiveRecord::Migration[5.0]
   def change
+    add_column :items, :soldout, :boolean, null: false, default: false
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200516050558) do
+ActiveRecord::Schema.define(version: 20200518122346) do
 
   create_table "addresses", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "post_code",    null: false
@@ -50,19 +50,20 @@ ActiveRecord::Schema.define(version: 20200516050558) do
   end
 
   create_table "items", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.string   "name",                             null: false
-    t.text     "introduction",       limit: 65535, null: false
-    t.string   "category_id",                      null: false
+    t.string   "name",                                             null: false
+    t.text     "introduction",       limit: 65535,                 null: false
+    t.string   "category_id",                                      null: false
     t.string   "size"
     t.string   "brand"
-    t.string   "condition_id",                     null: false
-    t.string   "postage_player_id",                null: false
-    t.string   "region_id",                        null: false
-    t.string   "preparation_day_id",               null: false
-    t.integer  "price",                            null: false
-    t.integer  "user_id",                          null: false
-    t.datetime "created_at",                       null: false
-    t.datetime "updated_at",                       null: false
+    t.string   "condition_id",                                     null: false
+    t.string   "postage_player_id",                                null: false
+    t.string   "region_id",                                        null: false
+    t.string   "preparation_day_id",                               null: false
+    t.integer  "price",                                            null: false
+    t.integer  "user_id",                                          null: false
+    t.datetime "created_at",                                       null: false
+    t.datetime "updated_at",                                       null: false
+    t.boolean  "soldout",                          default: false, null: false
     t.index ["user_id"], name: "index_items_on_user_id", using: :btree
   end
 


### PR DESCRIPTION
# What
出品中/売却済みなどの状態をテーブルで登録できるようにし、
且つ出品した商品は、デフォルトで出品中(soldout = false = 0)の状態で登録されるようにする
※売却済み(soldout = ture = 1)

# Why
本アプリケーションの必須機能である、購入機能の実装のため