### PR TITLE
商品購入 機能実装

### DIFF
--- a/app/assets/stylesheets/items/_show.scss
+++ b/app/assets/stylesheets/items/_show.scss
@@ -142,6 +142,9 @@
                 text-decoration: none;
               }
             }
+            .sold{
+              color: red;
+            }
           }
         }
       }

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -9,6 +9,7 @@ class OrdersController < ApplicationController
       Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
       customer =Payjp::Customer.retrieve(@card.customer_id)
       @default_card_information = customer.cards.retrieve(@card.card_id)
+      @address = Address.find_by(user_id: current_user.id)
     end
   end
 

--- a/app/controllers/orders_controller.rb
+++ b/app/controllers/orders_controller.rb
@@ -23,6 +23,7 @@ class OrdersController < ApplicationController
   end
 
   def done
+    Item.update(soldout: current_user.id)
   end
 
   private

--- a/app/views/items/show.html.haml
+++ b/app/views/items/show.html.haml
@@ -75,17 +75,21 @@
                 %i.fa.fa-star
                 お気に入り 0
             %ul.optional
-              - if user_signed_in? && current_user.id == @item.user_id
-                %li.editlBtn
-                  = link_to edit_item_path(@item.id) do
-                    編集
-                %li.deletelBtn
-                  = link_to item_path, method: "delete" do
-                    削除
+              - if @item.soldout == false
+                - if user_signed_in? && current_user.id == @item.user_id
+                  %li.editlBtn
+                    = link_to edit_item_path(@item.id) do
+                      編集
+                  %li.deletelBtn
+                    = link_to item_path, method: "delete" do
+                      削除
+                - else
+                  %li.optionalBtn
+                    = link_to item_orders_path(@item.id) do
+                      購入
               - else
-                %li.optionalBtn
-                  = link_to item_orders_path(@item.id) do
-                    購入
+                .sold
+                  SOLD OUT
         .commentBox
           %ul.commentContents
           %form#new_comment.new_comment{"accept-charset" => "UTF-8", :action => "#", :method => "post"}

--- a/app/views/orders/index.html.haml
+++ b/app/views/orders/index.html.haml
@@ -43,7 +43,7 @@
         %li
           %a{href: "#"} 変更する
       .shipping__address
-        〇〇県▲▲市
+        = @address.prefectures
     .buy
     = form_tag(action: :pay, method: :post) do
       %button{type:'submit'}


### PR DESCRIPTION
 # What
①購入済み商品が購入できないように実装
②発送先住所がユーザー登録時の住所が反映されるようにする

 # Why
①商品詳細ページで購入済みの場合購入ボタンが表示されないようにした
②商品購入確認ページにて発送先住所を表示するようにした

 # 画面
①https://gyazo.com/96f5fca0367ca5e0939e10624738aa42
②https://gyazo.com/a3eb8320ee68153c6de845af4642c971