### PR TITLE
デプロイ担当者と以外との条件分岐

### DIFF
--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,9 +20,8 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     if @item.valid?
       @item.save
-      redirect_to new_item_path
     else
-      render :new
+      redirect_to new_item_path
     end
   end
 

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -20,8 +20,9 @@ class ItemsController < ApplicationController
     @item = Item.new(item_params)
     if @item.valid?
       @item.save
-    else
       redirect_to new_item_path
+    else
+      render :new
     end
   end
 

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -4,7 +4,11 @@ class ImageUploader < CarrierWave::Uploader::Base
   # include CarrierWave::MiniMagick
 
   # Choose what kind of storage to use for this uploader:
-  storage :fog
+  if Rails.env.development? || Rails.env.test?
+    storage :file
+  else
+    storage :fog
+  end
 
   # Override the directory where uploaded files will be stored.
   # This is a sensible default for uploaders that are meant to be mounted:

--- a/config/initializers/carrierwave.rb
+++ b/config/initializers/carrierwave.rb
@@ -3,15 +3,18 @@ require 'carrierwave/storage/file'
 require 'carrierwave/storage/fog'
 
 CarrierWave.configure do |config|
-  config.storage = :fog
-  config.fog_provider = 'fog/aws'
-  config.fog_credentials = {
-    provider: 'AWS',
-    aws_access_key_id: Rails.application.secrets.aws_access_key_id,
-    aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
-    region: 'ap-northeast-1'
-  }
-
-  config.fog_directory  = 'freemarket74b'
-  config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket74b'
+  if Rails.env.development? || Rails.env.test? #開発とテストは今まで通り
+    config.storage = :file
+  elsif Rails.env.production? #本番はS3に保存
+    config.storage = :fog
+    config.fog_provider = 'fog/aws'
+    config.fog_credentials = {
+      provider: 'AWS',
+      aws_access_key_id: Rails.application.secrets.aws_access_key_id,
+      aws_secret_access_key: Rails.application.secrets.aws_secret_access_key,
+      region: 'ap-northeast-1'
+    }
+    config.fog_directory  = 'freemarket74b'
+    config.asset_host = 'https://s3-ap-northeast-1.amazonaws.com/freemarket74b'
+  end
 end


### PR DESCRIPTION
#what
image_uploderとcarrieweveでの
デプロイ担当者と以外との条件分岐の追加

#why
デプロイ担当者以外まで本番環境の環境変数を参照しようとしており、担当者以外はrails s出来ない仕様になっていたため。