### PR TITLE
編集の際にカテゴリーを継承できるようになりました。

### DIFF
--- a/app/assets/javascripts/items_category.js
+++ b/app/assets/javascripts/items_category.js
@@ -1,6 +1,6 @@
 $(document).on('turbolinks:load',(function(){
   var loc = location.pathname;
-  if( loc == "/items/new" || loc.indexOf("edit") != -1){
+  if( loc == "/items/new"){
     $.ajax({
       url: "/items/set_parents"
     }).done(function(data){
@@ -53,6 +53,54 @@ $(document).on('turbolinks:load',(function(){
           })
         }
       })
+    })
+  }
+
+  if(loc.indexOf("edit") != -1){
+      $(".select-parent").on("change", function(){
+      $(".select-child").remove();
+      $(".select-grandchild").remove();
+      if($(this).val() == ""){
+        $(".select-parent").attr("id"  , "select-parent");
+        $(".select-parent").attr("name", "item[category_id]");
+        $(".select-parent").css("margin-bottom", "0");
+      }else{
+        $.ajax({
+          url     : "/items/set_children",
+          data    : {parent_id: $(this).val()},
+          dataType: "json"
+        }).done(function(data){
+          $(".select-parent").attr("id"  , "parent_category");
+          $(".select-parent").attr("name", "select-parent");
+          $(".select-parent").css("margin-bottom", "10px");
+          $("#category-select").append(`<select class="new-wrapper__main__input-select select-child" name="item[category_id]" id="item_category_id"><option value="">選択してください</option></select>`);
+          data.children.forEach(function(child){
+            $(".select-child").append(`<option value="${child.id}">${child.name}</option>`);
+          })
+        })
+      }
+    })
+    $("#category-select").on("change", ".select-child", function(){
+      $(".select-grandchild").remove();
+      if($(this).val() == ""){
+        $(".select-child").attr("id"  , "item_category_id");
+        $(".select-child").attr("name", "item[category_id]");
+        $(".select-child").css("margin-bottom", "0");
+      }else{
+        $.ajax({
+          url     : "/items/set_grandchildren",
+          data    : {ancestry: `${$(".select-parent").val()}/${$(this).val()}`},
+          dataType: "json"
+        }).done(function(data){
+          $(".select-child").attr("id"  , "select-parent");
+          $(".select-child").attr("name", "select-parent");
+          $(".select-child").css("margin-bottom", "10px");
+          $("#category-select").append(`<select class="new-wrapper__main__input-select select-grandchild" name="item[category_id]" id="item_category_id"><option value="">選択してください</option></select>`);
+          data.grandchildren.forEach(function(grandchild){
+            $(".select-grandchild").append(`<option value="${grandchild.id}">${grandchild.name}</option>`);
+          })
+        })
+      }
     })
   }
 }))

--- a/app/controllers/items_controller.rb
+++ b/app/controllers/items_controller.rb
@@ -26,6 +26,24 @@ class ItemsController < ApplicationController
   end
 
   def edit
+    grandchild_category = @item.category
+    child_category = grandchild_category.parent
+
+
+    @category_parent_array = {}
+    Category.where(ancestry: nil).each do |parent|
+      @category_parent_array[parent.name] = parent.id
+    end
+
+    @category_children_array = {}
+    Category.where(ancestry: child_category.ancestry).each do |children|
+      @category_children_array[children.name] = children.id
+    end
+
+    @category_grandchildren_array = {}
+    Category.where(ancestry: grandchild_category.ancestry).each do |grandchildren|
+      @category_grandchildren_array[grandchildren.name] = grandchildren.id
+    end
   end
 
   def update

--- a/app/views/items/_form.html.haml
+++ b/app/views/items/_form.html.haml
@@ -47,6 +47,15 @@
         カテゴリー
         %span.require 必須
       #category-select
+        -if @item.category.present?
+          .category-wrapper-select__box
+            = f.select :category_id, @category_parent_array, {selected: @item.category.parent.parent.id}, { class: 'new-wrapper__main__input-select select-parent', id: 'parent_category'}
+          .category-wrapper-select#children_wrapper
+            .category-wrapper-select__box
+              = f.select :category_id, @category_children_array, {selected: @item.category.parent.id}, {class: 'new-wrapper__main__input-select select-child', id: 'child_category'}
+          .category-wrapper-select#grandchildren_wrapper
+            .category-wrapper-select__box
+              = f.select :category_id, @category_grandchildren_array, {selected: @item.category.parent.id}, {class: 'new-wrapper__main__input-select select-grandchild', id: 'grandchild_category'}
       .new-wrapper__main__title.spacing
         ブランド
         %span.any 任意


### PR DESCRIPTION
#what
- app/assets/javascripts/items_category.js
編集の時様に動的なフォームの生成を用意
- app/controllers/items_controller.rb
その商品のカテゴリーを定義
- app/views/items/_form.html.haml
編集画面でカテゴリーを初期設定で表示しておく

#why
ユーザービリティ向上のため
